### PR TITLE
SMRT-334: adding the hostname check to the lib

### DIFF
--- a/lib/streaming_metrics/hostname.ex
+++ b/lib/streaming_metrics/hostname.ex
@@ -1,0 +1,13 @@
+defmodule StreamingMetrics.Hostname do
+  use Agent
+
+  def start_link(_opts) do
+    hostname = System.get_env("HOSTNAME")
+    Agent.start_link(fn -> hostname end, name: __MODULE__)
+  end
+
+  def get() do
+    Agent.get(__MODULE__, fn name -> name end)
+  end
+
+end

--- a/test/streaming_metrics/hostname_test.exs
+++ b/test/streaming_metrics/hostname_test.exs
@@ -1,0 +1,16 @@
+defmodule StreamingMetrics.HostnameTest do
+  use ExUnit.Case
+
+  @hostname "foobar"
+
+  setup_all do
+    System.put_env("HOSTNAME", @hostname)
+    {:ok, hostname} = StreamingMetrics.Hostname.start_link([])
+    %{hostname: hostname}
+  end
+
+  test "agent gets the correct hostname", %{hostname: hostname} do
+    hostname = StreamingMetrics.Hostname.get()
+    assert hostname == @hostname
+  end
+end


### PR DESCRIPTION
co-authored-by: Jeff Grunewald <jeff@grunewalddesign.com>

Added the hostname check to the library so the testing can be done independently of the downstream applications.